### PR TITLE
Move to the new Google Maps API.

### DIFF
--- a/server/honeybadger/google_api.py
+++ b/server/honeybadger/google_api.py
@@ -1,0 +1,31 @@
+import json
+import urllib2
+
+from honeybadger import log
+
+GOOGLE_API_KEY = ''
+GOOGLE_API_URL = "https://www.googleapis.com/geolocation/v1/geolocate?key={}".format(GOOGLE_API_KEY)
+
+def google_api(data):
+    """Make a request to the google maps api for given data
+
+    :arg data: dictionary containing data to send to google
+    """
+    data_json = json.dumps(data)
+    data_length = len(data_json)
+    req_headers = {
+        'Content-Type': 'application/json',
+        'Contnet-Length': data_length
+    }
+    request = urllib2.Request(GOOGLE_API_URL, data_json, req_headers)
+    transmission = urllib2.urlopen(request)
+    response = transmission.read()
+    transmission.close()
+    log.message("Google API Response: {}".format(response))
+    try:
+        return json.loads(response)
+
+    except Exception as e:
+        log.message("Could not parse json response: {}".format(e.message))
+
+    return None


### PR DESCRIPTION
Update to new api. Have tested this code on Void, Ubuntu, and Arch Linux (I have no Windoz or OSX machines running at this time so those have not been tested, but should work)

Note: The new api requires a key, to set the key edit the file server/google_api.py and paste your API key in the variable named GOOGLE_API_KEY.

Note: This update attempts to make as few changes as possible, but to ease future maintenance does change the data structure returned from parsers from a list to a dictionary, as the new maps api requires a json post.