### PR TITLE
Updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ An early prototype of HoneyBadger (v1) can be seen in the presentation "[Hide an
 4. Initialize the database. The provided username and password will become the administrator account.
 
     ```
-    $ python3
+    $ python
     >>> import honeybadger
     >>> honeybadger.initdb(<username>, <password>)
     ```
@@ -37,7 +37,7 @@ An early prototype of HoneyBadger (v1) can be seen in the presentation "[Hide an
 5. Start the HoneyBadger server. API keys will need to be provided to be able to use maps and geolocation services.
 
     ```
-    $ python3 ./honeybadger.py -gk <GOOGLE_API_KEY> -ik <IPSTACK_API_KEY>
+    $ python ./honeybadger.py -gk <GOOGLE_API_KEY> -ik <IPSTACK_API_KEY>
     ```
 
 Honeybadger will still run without these API keys, but mapping and geolocation functionality will be limited as a result.
@@ -45,8 +45,8 @@ Honeybadger will still run without these API keys, but mapping and geolocation f
 View usage information with either of the following:
 
    ```
-   $ python3 ./honeybadger.py -h
-   $ python3 ./honeybadger.py --help
+   $ python ./honeybadger.py -h
+   $ python ./honeybadger.py --help
    ```
 
 
@@ -61,7 +61,7 @@ Clicking the "demo" button next to any of the targets will launch a demo web pag
 Make a mess and want to start over fresh? Do this.
 
 ```
-$ python3
+$ python
 >>> import honeybadger
 >>> honeybadger.dropdb()
 >>> honeybadger.initdb(<username>, <password>)

--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ An early prototype of HoneyBadger (v1) can be seen in the presentation "[Hide an
     >>> honeybadger.initdb(<username>, <password>)
     ```
 
-5. Start the HoneyBadger server.
+5. Start the HoneyBadger server. API keys will need to be provided to be able to use maps and geolocation services.
 
     ```
-    $ python3 ./honeybadger.py
+    $ python3 ./honeybadger.py -gk <GOOGLE_API_KEY> -ik <IPSTACK_API_KEY>
     ```
+
+Honeybadger will still run without these API keys, but mapping and geolocation functionality will be limited as a result.
+
 
 6. Visit the application and authenticate.
 7. Add users and targets as needed using their respective pages.

--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ An early prototype of HoneyBadger (v1) can be seen in the presentation "[Hide an
     >>> honeybadger.initdb(<username>, <password>)
     ```
 
-5. Start the HoneyBadger server. API keys will need to be provided to be able to use maps and geolocation services.
+5. Start the HoneyBadger server. API keys are required to use maps and geolocation services.
 
     ```
     $ python ./honeybadger.py -gk <GOOGLE_API_KEY> -ik <IPSTACK_API_KEY>
     ```
 
-Honeybadger will still run without these API keys, but mapping and geolocation functionality will be limited as a result.
+    Honeybadger will still run without the API keys, but mapping and geolocation functionality will be limited as a result.
 
-View usage information with either of the following:
+    View usage information with either of the following:
 
    ```
    $ python ./honeybadger.py -h

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An early prototype of HoneyBadger (v1) can be seen in the presentation "[Hide an
 
 ### Pre-requisites
 
-* Python 2.x
+* Python 3.x
 
 ### Installation (Ubuntu and OS X)
 
@@ -29,7 +29,7 @@ An early prototype of HoneyBadger (v1) can be seen in the presentation "[Hide an
 4. Initialize the database. The provided username and password will become the administrator account.
 
     ```
-    $ python
+    $ python3
     >>> import honeybadger
     >>> honeybadger.initdb(<username>, <password>)
     ```
@@ -37,7 +37,7 @@ An early prototype of HoneyBadger (v1) can be seen in the presentation "[Hide an
 5. Start the HoneyBadger server.
 
     ```
-    $ python ./honeybadger.py
+    $ python3 ./honeybadger.py
     ```
 
 6. Visit the application and authenticate.
@@ -51,7 +51,7 @@ Clicking the "demo" button next to any of the targets will launch a demo web pag
 Make a mess and want to start over fresh? Do this.
 
 ```
-$ python
+$ python3
 >>> import honeybadger
 >>> honeybadger.dropdb()
 >>> honeybadger.initdb(<username>, <password>)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ An early prototype of HoneyBadger (v1) can be seen in the presentation "[Hide an
 
 Honeybadger will still run without these API keys, but mapping and geolocation functionality will be limited as a result.
 
+View usage information with either of the following:
+
+   ```
+   $ python3 ./honeybadger.py -h
+   $ python3 ./honeybadger.py --help
+   ```
+
 
 6. Visit the application and authenticate.
 7. Add users and targets as needed using their respective pages.


### PR DESCRIPTION
Perhaps it's just my system, but I have to use `python3` because `python` defaults to the system version, python 2.7.5

Also, needed to add information about how to use API keys.